### PR TITLE
Made it so we can now use anything as a user/device/stream name except web components

### DIFF
--- a/src/clients/python/connectordb.py
+++ b/src/clients/python/connectordb.py
@@ -89,7 +89,8 @@ class User(ConnectorObject):
     def devices(self):
         #Returns the list of users accessible to this operator
         devs = []
-        for d in self.db.urlget(self.metaname+"/ls").json():
+        result = self.db.urlget(self.metaname+"/?special=ls")
+        for d in result.json():
             tmpd = Device(self.db,d["name"])
             tmpd.metadata = d
             devs.append(tmpd)
@@ -105,7 +106,9 @@ class Device(ConnectorObject):
     def streams(self):
         #Returns the list of users accessible to this operator
         strms = []
-        for s in self.db.urlget(self.metaname+"/ls").json():
+        result = self.db.urlget(self.metaname+"/?special=ls")
+        print result
+        for s in result.json():
             tmps = Stream(self.db,s["name"])
             tmps.metadata = s
             strms.append(tmps)
@@ -181,10 +184,10 @@ class ConnectorDB(Device):
     def __init__(self,user,password,url="https://connectordb.com"):
         self.auth = HTTPBasicAuth(user,password)
         self.url = url
-        
-        Device.__init__(self,self,self.urlget("this").text)
 
-        
+        Device.__init__(self,self,self.urlget("?special=this").text)
+
+
     #Does error handling for a request result
     def handleresult(self,r):
         if r.status_code==401 or r.status_code==403:
@@ -211,9 +214,8 @@ class ConnectorDB(Device):
     def users(self):
         #Returns the list of users accessible to this operator
         usrs = []
-        for u in self.urlget("ls").json():
+        for u in self.urlget("?special=ls").json():
             tmpu = self.getuser(u["name"])
             tmpu.metadata = u
             usrs.append(tmpu)
         return usrs
-

--- a/src/plugins/rest/devices.go
+++ b/src/plugins/rest/devices.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"net/http"
 	"streamdb"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -12,8 +11,8 @@ import (
 )
 
 func getDevicePath(request *http.Request) (username string, devicename string, devicepath string) {
-	username = strings.ToLower(mux.Vars(request)["user"])
-	devicename = strings.ToLower(mux.Vars(request)["device"])
+	username = mux.Vars(request)["user"]
+	devicename = mux.Vars(request)["device"]
 	devicepath = username + "/" + devicename
 	return username, devicename, devicepath
 }
@@ -26,25 +25,10 @@ func GetThis(o streamdb.Operator, writer http.ResponseWriter, request *http.Requ
 	return nil
 }
 
-//GetDevice handles a {user}/{device} request
-func GetDevice(o streamdb.Operator, writer http.ResponseWriter, request *http.Request) error {
-	devname := strings.ToLower(mux.Vars(request)["device"])
-
-	switch devname {
-	default:
-		return ReadDevice(o, writer, request)
-	case "ls":
-		return ListDevices(o, writer, request)
-	case "favicon.ico":
-		writer.WriteHeader(http.StatusNotFound)
-		log.WithFields(log.Fields{"dev": o.Name(), "addr": request.RemoteAddr}).Debugln("Request for favicon")
-		return nil
-	}
-}
 
 //ListDevices lists the devices that the given user has
 func ListDevices(o streamdb.Operator, writer http.ResponseWriter, request *http.Request) error {
-	usrname := strings.ToLower(mux.Vars(request)["user"])
+	usrname := mux.Vars(request)["user"]
 	logger := log.WithFields(log.Fields{"dev": o.Name(), "addr": request.RemoteAddr, "op": "ListDevices", "arg": usrname})
 	logger.Debugln()
 	d, err := o.ReadAllDevices(usrname)

--- a/src/plugins/rest/streams.go
+++ b/src/plugins/rest/streams.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"streamdb"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -13,26 +12,11 @@ import (
 )
 
 func getStreamPath(request *http.Request) (username string, devicename string, streamname string, streampath string) {
-	username = strings.ToLower(mux.Vars(request)["user"])
-	devicename = strings.ToLower(mux.Vars(request)["device"])
-	streamname = strings.ToLower(mux.Vars(request)["stream"])
+	username = mux.Vars(request)["user"]
+	devicename = mux.Vars(request)["device"]
+	streamname = mux.Vars(request)["stream"]
 	streampath = username + "/" + devicename + "/" + streamname
 	return username, devicename, streamname, streampath
-}
-
-//GetStream gets an existing stream from a REST API request
-func GetStream(o streamdb.Operator, writer http.ResponseWriter, request *http.Request) error {
-	streamname := strings.ToLower(mux.Vars(request)["stream"])
-	switch streamname {
-	default:
-		return ReadStream(o, writer, request)
-	case "ls":
-		return ListStreams(o, writer, request)
-	case "favicon.ico":
-		writer.WriteHeader(http.StatusNotFound)
-		log.WithFields(log.Fields{"dev": o.Name(), "addr": request.RemoteAddr}).Debugln("Request for favicon")
-		return nil
-	}
 }
 
 //ListStreams lists the streams that the given device has

--- a/src/plugins/rest/users.go
+++ b/src/plugins/rest/users.go
@@ -3,32 +3,11 @@ package rest
 import (
 	"net/http"
 	"streamdb"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/gorilla/mux"
 )
-
-//GetUser runs the GET operation routing for REST
-func GetUser(o streamdb.Operator, writer http.ResponseWriter, request *http.Request) error {
-	usrname := strings.ToLower(mux.Vars(request)["user"])
-
-	//there can be certain commands in place of a username - those represent invalid user names
-	switch usrname {
-	default:
-		return ReadUser(o, writer, request)
-	case "ls":
-		return ListUsers(o, writer, request)
-	case "this":
-		return GetThis(o, writer, request)
-	case "favicon.ico":
-		writer.WriteHeader(http.StatusNotFound)
-		log.WithFields(log.Fields{"dev": o.Name(), "addr": request.RemoteAddr}).Debugln("Request for favicon")
-		return nil
-	}
-
-}
 
 //ListUsers lists the users that the given operator can see
 func ListUsers(o streamdb.Operator, writer http.ResponseWriter, request *http.Request) error {
@@ -50,7 +29,7 @@ type userCreator struct {
 
 //CreateUser creates a new user from a REST API request
 func CreateUser(o streamdb.Operator, writer http.ResponseWriter, request *http.Request) error {
-	usrname := strings.ToLower(mux.Vars(request)["user"])
+	usrname := mux.Vars(request)["user"]
 	logger := log.WithFields(log.Fields{"dev": o.Name(), "addr": request.RemoteAddr, "op": "CreateUser", "arg": usrname})
 	logger.Infoln()
 	var a userCreator
@@ -73,7 +52,7 @@ func CreateUser(o streamdb.Operator, writer http.ResponseWriter, request *http.R
 
 //ReadUser reads the given user
 func ReadUser(o streamdb.Operator, writer http.ResponseWriter, request *http.Request) error {
-	usrname := strings.ToLower(mux.Vars(request)["user"])
+	usrname := mux.Vars(request)["user"]
 	logger := log.WithFields(log.Fields{"dev": o.Name(), "addr": request.RemoteAddr, "op": "ReadUser", "arg": usrname})
 	logger.Debugln()
 	u, err := o.ReadUser(usrname)
@@ -87,7 +66,7 @@ func ReadUser(o streamdb.Operator, writer http.ResponseWriter, request *http.Req
 
 //UpdateUser updates the metadata for existing user from a REST API request
 func UpdateUser(o streamdb.Operator, writer http.ResponseWriter, request *http.Request) error {
-	usrname := strings.ToLower(mux.Vars(request)["user"])
+	usrname := mux.Vars(request)["user"]
 	logger := log.WithFields(log.Fields{"dev": o.Name(), "addr": request.RemoteAddr, "op": "UpdateUser", "arg": usrname})
 	logger.Infoln()
 	u, err := o.ReadUser(usrname)
@@ -120,7 +99,7 @@ func UpdateUser(o streamdb.Operator, writer http.ResponseWriter, request *http.R
 
 //DeleteUser deletes existing user from a REST API request
 func DeleteUser(o streamdb.Operator, writer http.ResponseWriter, request *http.Request) error {
-	usrname := strings.ToLower(mux.Vars(request)["user"])
+	usrname := mux.Vars(request)["user"]
 	logger := log.WithFields(log.Fields{"dev": o.Name(), "addr": request.RemoteAddr, "op": "DeleteUser", "arg": usrname})
 	logger.Infoln()
 	err := o.DeleteUser(usrname)

--- a/src/plugins/rest/util.go
+++ b/src/plugins/rest/util.go
@@ -60,11 +60,14 @@ func ValidName(n string, err error) error {
 	if err != nil {
 		return err
 	}
-	if strings.Contains(n, "/") || strings.Contains(n, "\\") || strings.Contains(n, " ") || strings.Contains(n, "?") {
+	
+	if 	strings.Contains(n, "/") ||
+		strings.Contains(n, "\\") ||
+		strings.Contains(n, " ") ||
+		strings.Contains(n, "?") ||
+		len(n) == 0 {
 		return ErrInvalidName
 	}
-	if n == "ls" || n == "this" || n == "favicon.ico" || len(n) == 0 {
-		return ErrInvalidName
-	}
+
 	return nil
 }


### PR DESCRIPTION
Pushed the special functions into get params.
Changed the case sensitivity to reflect the underlying database, otherwise we may have had people create an account/device/stream through the web interface but unable to access REST.
