### PR TITLE
Wraps jsonschemas to work with jsonform so we can manually submit them.

### DIFF
--- a/src/connectordb/plugins/webclient/static/css/connectordb.css
+++ b/src/connectordb/plugins/webclient/static/css/connectordb.css
@@ -90,34 +90,6 @@ body {
 	border-width:0px;
 }
 
-/* To kill off the stupid roboto theme that makes forms invisible */
-
-.form-control {
-  border: 1px solid #d2d2d2;
-  padding: 1em;
-  background-color: white;
-  background-image: none;
-}
-
-.form-control:focus{
-background-image:none;
-
-  /**padding: 1em;**/
-  float: none;
-  border: 1px solid #66afe9;
-
-}
-
-.form-group .form-control:focus, .form-group-default .form-control:focus {
-background-image:none;
-
-  padding: 1em;
-  float: none;
-  border: 1px solid #66afe9;
-
-}
-
-
 .navbar-inverse {
   background-color: #212a5e;
   border-color: #212a5e;

--- a/src/connectordb/plugins/webclient/templates/device_info.html
+++ b/src/connectordb/plugins/webclient/templates/device_info.html
@@ -71,6 +71,7 @@
                     <label for="datatype">Type of Data</label>
                     <select id="datatype" name="datatype" class="form-control">
                       <option value="{&quot;type&quot;: &quot;object&quot;,&quot;properties&quot;: {&quot;value&quot;: {&quot;type&quot;: &quot;number&quot;,&quot;description&quot;:&quot;A numeric value&quot;}}}">Number</option>
+                      <option value="{&quot;type&quot;: &quot;number&quot;,&quot;description&quot;:&quot;A numeric value&quot;}">Number_tiny</option>
                       <option value="{&quot;type&quot;: &quot;object&quot;,&quot;properties&quot;: {&quot;latitude&quot;: {&quot;type&quot;: &quot;number&quot;,&quot;description&quot;:&quot;Latitude in DD&quot;},&quot;longitude&quot;: {&quot;type&quot;: &quot;number&quot;,&quot;description&quot;:&quot;Longitude in DD&quot;}}}">Coordinate</option>
                     </select>
                 </div>

--- a/src/connectordb/plugins/webclient/templates/stream.html
+++ b/src/connectordb/plugins/webclient/templates/stream.html
@@ -54,8 +54,27 @@
 
     <script type="text/javascript">
     $(document).ready(function(){
+        // We get the schama for this stream, but it may not be ready to be
+        // parsed by jsonForm, since jsonForm doesn't fully follow the
+        // jsonschema specification.
         var schema = JSON.parse({{ .stream.Type }})
         console.log(schema)
+
+        // Did we have to wrap the schema to get it to play nicely with jsonform?
+        var schemaIsWrapped = false;
+        if(schema["type"] !== "object") {
+            schemaIsWrapped = true;
+            var tmp = {
+                "type":"object",
+                "properties": {
+                    "value":schema
+                }
+            }
+
+            // wrap the schema
+            schema = tmp
+        }
+
         $('#result-form').jsonForm({
           schema:  schema,
           onSubmit: function (errors, values) {
@@ -64,8 +83,14 @@
               console.log(errors);
               return false;
             }
-            $("#formdata").val(JSON.stringify(values));
-            alert(JSON.stringify(values));
+
+            if(schemaIsWrapped) {
+                $("#formdata").val(JSON.stringify(values["value"]));
+            } else {
+                $("#formdata").val(JSON.stringify(values));
+            }
+
+            alert($("#formdata").val());
             $("#shadow-form").submit();
             return false;
           }


### PR DESCRIPTION
jsonform doesn't follow jsonschema specification in that it only allows
schemas that are of type object. This code wraps them to look like an object
and unwraps them upon submission.

Fixes #131
