### PR TITLE
Makes only owner device or admin able to write

### DIFF
--- a/src/clients/python/connectordb_test.py
+++ b/src/clients/python/connectordb_test.py
@@ -414,7 +414,13 @@ class TestConnectorDB(unittest.TestCase):
         usr.create("py@email","mypass")
         dev = usr["mydevice"]
         dev.create()
+
+        db = connectordb.ConnectorDB(dev.apikey,url="http://localhost:8000")
+
         s = db["teststream"]
+
+
+
         s.create({"type": "number"})
 
         s.insert(3)

--- a/src/connectordb/streamdb/operator/authoperator/io.go
+++ b/src/connectordb/streamdb/operator/authoperator/io.go
@@ -32,9 +32,17 @@ func (o *AuthOperator) InsertStreamByID(streamID int64, substream string, data d
 		}
 
 		//Since the writer is not the owner, if the stream is a downlink, write to the downlink substream
-		if substream == "" && strm.Downlink {
+		if strm.Downlink {
 			substream = "downlink"
+		} else {
+			//It isn't a downlink stream - check if current device is an admin
+			if !dev.IsAdmin {
+				//The device can't write the stream - this is to stop potential errors when users unknowingly
+				//write to one of their devices' streams without understanding what that means
+				return ErrPermissions
+			}
 		}
+
 	} else {
 		//The writer is reader. Ensure the sender field is empty
 		for i := range data {

--- a/src/connectordb/streamdb/operator/authoperator/stream.go
+++ b/src/connectordb/streamdb/operator/authoperator/stream.go
@@ -1,9 +1,6 @@
 package authoperator
 
-import (
-	"connectordb/streamdb/users"
-	"fmt"
-)
+import "connectordb/streamdb/users"
 
 //ReadAllStreamsByDeviceID reads all streams associated with the device
 func (o *AuthOperator) ReadAllStreamsByDeviceID(deviceID int64) ([]users.Stream, error) {
@@ -92,7 +89,6 @@ func (o *AuthOperator) ReadStreamByDeviceID(deviceID int64, streamname string) (
 func (o *AuthOperator) UpdateStream(modifiedstream *users.Stream) error {
 	originalStream, err := o.BaseOperator.ReadStreamByID(modifiedstream.StreamId)
 	if err != nil {
-		fmt.Println("first")
 		return err
 	}
 
@@ -109,7 +105,6 @@ func (o *AuthOperator) UpdateStream(modifiedstream *users.Stream) error {
 	permission := myDevice.RelationToStream(originalStream, streamsDevice)
 
 	if modifiedstream.RevertUneditableFields(*originalStream, permission) > 0 {
-		fmt.Println("third")
 		return ErrPermissions
 	}
 
@@ -118,7 +113,6 @@ func (o *AuthOperator) UpdateStream(modifiedstream *users.Stream) error {
 		o.UserLogStreamID(originalStream.StreamId, "UpdateStream")
 	}
 
-	fmt.Println("fourth")
 	return err
 }
 


### PR DESCRIPTION
Closes #223 
Also fixed Python test bug as well as debug prints on update device
