### PR TITLE
Add mobile web app capable meta tags

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -16,6 +16,8 @@
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes"/>
   <!--<link rel="icon" href="./favicon.ico" />-->
   <title>heedy</title>
 </head>


### PR DESCRIPTION
Hey,

Just starting to use Heedy and liking it so far. This is just a suggestion if you're interested - it means browsers will allow this to be "installed" i.e. added to the home screen and displayed separately in app switchers etc.

Cheers,
Matt